### PR TITLE
Fixed bug in AddCommentForm to clear the text field after a comment

### DIFF
--- a/frontend/src/components/Question/AddCommentForm.js
+++ b/frontend/src/components/Question/AddCommentForm.js
@@ -42,7 +42,7 @@ const AddCommentForm = ({ state, dispatch }) => {
             likes: [],
           }),
         }))
-        setCommentContent('')
+        dispatch(setCommentContent(''))
       }
     }
   }


### PR DESCRIPTION
I have replaced setCommentContent('') Quest\frontend\src\components\Question\AddCommentForm.js at line 45
```diff
-setCommentContent('')

+dispatch(setCommentContent(''))
```
This change clears the text field after the user has sent a message.